### PR TITLE
Adds tags and commits for the failed-strategy 

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
@@ -95,7 +95,7 @@ public class MapObject {
       /* TODO create a new Converter class and move this method there for reuse */
 
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
-            return Integer.valueOf(value);
+            return 1;
         } else if (Double.class.equals(clazz) || double.class.equals(clazz)) {
             return Double.valueOf(value);
         } else if (Long.class.equals(clazz) || long.class.equals(clazz)) {

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
@@ -32,7 +32,7 @@ public class MapObjectTestCase {
     private static final String VAL_STRING = "test123";
     private static final String VAL_MULTILINE_STRING =
         "\n\n\n\n\r\n\t\t\ttest123 \r\n\t\t\t\ttest123" + System.getProperty("line.separator");
-    private static final Integer VAL_INTEGER = 123;
+    private static final Integer VAL_INTEGER = 1;
     private static final Boolean VAL_BOOLEAN = true;
     private static final Double VAL_DOUBLE = 3.4;
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Adds tags `failed_01: Single method modification - return value` and `failed_02: Single test method modification - constant value` for the commits for the failed strategy.
```bash
18:39 $ git show failed_01
tag failed_01
Tagger: hemanik <hemanikatyal@gmail.com>
Date:   Wed Aug 2 17:52:23 2017 +0530

Single method modification - return value

commit 435c21ffe028857b34b6e32f663a34c4df9ff107 (tag: show, tag: failed_01)
Author: hemanik <hemanikatyal@gmail.com>
Date:   Wed Aug 2 17:50:39 2017 +0530

    failed: induces error by changing the returned value
    
    - org.jboss.arquillian.container.impl.MapObjectTestCase

diff --git a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
index 973f5ae..809a29a 100644
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
@@ -95,7 +95,7 @@ public class MapObject {
       /* TODO create a new Converter class and move this method there for reuse */
 
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
-            return Integer.valueOf(value);
+            return 1;
         } else if (Double.class.equals(clazz) || double.class.equals(clazz)) {
             return Double.valueOf(value);
         } else if (Long.class.equals(clazz) || long.class.equals(clazz)) {
@@ -106,4 +106,4 @@ public class MapObject {
 
         return value;
     }
-}
\ No newline at end of file
+}

```
``` bash
18:39 $ git show failed_02
tag failed_02
Tagger: hemanik <hemanikatyal@gmail.com>
Date:   Wed Aug 2 17:54:31 2017 +0530

Single test method modification - constant value

commit b1644325a9b7b7d84ee0054189be2e17cdc8005b (HEAD -> failed, tag: failed_02, origin/failed)
Author: hemanik <hemanikatyal@gmail.com>
Date:   Wed Aug 2 17:52:51 2017 +0530

    failed: fixes induced error by changing CONSTANT value
    
    + org.jboss.arquillian.container.impl.MapObjectTestCase

diff --git a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
index bfa4d95..6f872eb 100644
--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
@@ -32,7 +32,7 @@ public class MapObjectTestCase {
     private static final String VAL_STRING = "test123";
     private static final String VAL_MULTILINE_STRING =
         "\n\n\n\n\r\n\t\t\ttest123 \r\n\t\t\t\ttest123" + System.getProperty("line.separator");
-    private static final Integer VAL_INTEGER = 123;
+    private static final Integer VAL_INTEGER = 1;
     private static final Boolean VAL_BOOLEAN = true;
     private static final Double VAL_DOUBLE = 3.4;
```
