### PR TITLE
Additional tags added for skipping tests functionality and failsafe

### DIFF
--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/ITDummyTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/ITDummyTestCase.java
@@ -1,0 +1,12 @@
+package org.jboss.arquillian.core;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertTrue;
+
+public class ITDummyTestCase {
+    @Test
+    public void dummyTest() {
+        assertTrue(true);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skip>true</skip>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
           <printSummary>true</printSummary>
@@ -87,8 +88,28 @@
             <include>**/*TestCase.java</include>
             <include>**/*TestSuite.java</include>
           </includes>
+          <excludes>
+            <exclude>**/IT*.java</exclude>
+          </excludes>
           <useFile>true</useFile>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <trimStackTrace>false</trimStackTrace>
+          <printSummary>true</printSummary>
+          <useFile>true</useFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
#### Short description of what this resolves:
New tags are needed for the skipping test functionality. The details of the newly added tags are as follows:

1. tag skip_00: *Enable both surefire and failsafe plugin with sample integration test* - [Related Commit](https://gist.github.com/hemanik/a39450ca9e867c53fb48975a189f0bc3)
2. ~~tag skip_01: *Skip surefire and enable just failsafe plugin with sample integration test* - [Related Commit](https://gist.github.com/hemanik/585d757c1aad60178d4ace6153d8b3f3)~~
[Replacement of the earlier failsafe tag with msg "Disable surefire and enable just failsafe plugin" to also include a dummy integration test.] 

3. tag skip_02: *Configure skipITs as default property in pom* -  [Related Commit](https://gist.github.com/hemanik/cff0385bcae94ded42ad04d9dab2592a)
4. ~~tag skip_03: *Configures skipTests as default property in pom* - [Related Commit](https://gist.github.com/hemanik/e23e6c7f4bbfe17e0e435a7dc7f502d7)~~

5. tag skip_04: *Configure skipTests property in plugin configuration section of pom* - [Related Commit](https://gist.github.com/hemanik/4b3d3616bde552acbaedb4a7ad6e1493)

6. tag skip_05: *Configure skipITs as custom default property in pom* - [Related Commit](https://gist.github.com/hemanik/c3834bce5911fd29d63605e52b431308)

**Fixes**:
